### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
         needs: [deps, build, push]
         if: always()
         runs-on: ubuntu-latest
+        permissions: {}
         steps:
             - name: Generate summary
               run: |


### PR DESCRIPTION
Potential fix for [https://github.com/lbenicio/lbenicio.github.io/security/code-scanning/10](https://github.com/lbenicio/lbenicio.github.io/security/code-scanning/10)

Add an explicit `permissions` block for the `report` job in `.github/workflows/release.yml`.

Best minimal fix without changing behavior:
- In the `report` job definition, add:
  - `permissions: {}`
This explicitly grants no `GITHUB_TOKEN` permissions to that job, which matches current behavior since it only generates a step summary and does not require repository/package access.

Region to change:
- `.github/workflows/release.yml`, inside `jobs.report`, between `runs-on` and `steps`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
