### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
 jobs:
     deps:
         runs-on: ubuntu-latest
+        permissions: {}
         steps:
             - name: Pull base images
               run: |


### PR DESCRIPTION
Potential fix for [https://github.com/lbenicio/lbenicio.github.io/security/code-scanning/9](https://github.com/lbenicio/lbenicio.github.io/security/code-scanning/9)

Add an explicit `permissions` block to the `deps` job in `.github/workflows/release.yml`.

- **General fix**: define `permissions` either at workflow root or per job; prefer least privilege required.
- **Best fix here (minimal and safe)**: add `permissions: {}` to the `deps` job, since it does not need repository/package write scopes. This avoids changing behavior of other jobs that already have explicit scoped permissions.
- **Where to change**: in `.github/workflows/release.yml`, under `jobs.deps`, directly after `runs-on: ubuntu-latest`.
- **No imports/dependencies/methods** are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
